### PR TITLE
No exception when endpoint returns status 204

### DIFF
--- a/src/api_data_fetcher.php
+++ b/src/api_data_fetcher.php
@@ -347,7 +347,7 @@ class ApiDataFetcher{
 		// TODO: vyresit zalogovani parametru POSTem
 
 		$content = $u->getContent();
-		if(!strlen($content)){
+		if(!strlen($content) && ($this->status_code!=204)){
 			throw new Exception("No content on $url (HTTP $this->status_code)");
 		}
 


### PR DESCRIPTION
Empty response can be valid when endpoint returns status code 204